### PR TITLE
Add Material Icons For Github extension link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [JSON formatter](https://github.com/callumlocke/json-formatter) - Makes JSON/JSONP easy to read.
 - [JSONView](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc) - Validate and view JSON documents.
 - [Kuker](https://chrome.google.com/webstore/detail/kuker/glgnienmpgmfpkigngkmieconbnkmlcn) - Debug applications made with React, Redux, Angular, Vue and many more.
+- [Material Icons for Github](https://github.com/Claudiohbsantos/github-material-icons-extension) - Show Material design Dev icons in Github code explorer.
 - [OctoLinker](https://octolinker.github.io/) - Lets you navigate through projects on GitHub by making references in code clickable.
 - [Octotree](https://github.com/buunguyen/octotree) - Gives a file tree view on the side of each repository that you visit that you can use to navigate over the codebase.
 - [Open GitHub in IDE](https://chrome.google.com/webstore/detail/open-github-in-ide/bmifnnfmccmleigpaolofacllndmfned) - This extension allows you to open files in your IDE directly from GitHub, assuming the repository you are working on is cloned on your computer. When a fragment of a file is displayed, your IDE opens the file and puts the cursor at the desired line.


### PR DESCRIPTION
This PR adds a link to a new extension. Please feel free to let me know if you'd like the description revised :) 