### PR TITLE
docs: add Linguist to extensions list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Web Archives](https://github.com/dessant/web-archives) - Browser extension for viewing archived and cached versions of web pages.
 - [Buster](https://github.com/dessant/buster) - Captcha solver extension for humans.
 - [SimpleLogin](https://github.com/simple-login/browser-extension) - Protect your email address using email alias. 100% open source and can be self-hosted.
+- [Linguist](https://github.com/translate-tools/linguist) - Powerful tool for translate pages and text, which are ready to replace your favorite translate service.
 
 [![CC4](https://img.shields.io/badge/license-CC4-0a0a0a.svg?style=flat&colorA=0a0a0a)](https://creativecommons.org/licenses/by/4.0/)
 [![Lists](https://img.shields.io/badge/-more%20lists-0a0a0a.svg?style=flat&colorA=0a0a0a)](https://github.com/learn-anything/curated-lists)


### PR DESCRIPTION
Linguist is a powerful browser extension for translate pages and text, which are ready to replace your favorite translate service.

This extension is support [custom translators](https://github.com/translate-tools/linguist/blob/master/docs/CustomTranslator.md), so users may use any translation service in the world. Even private service deployed on localhost, to reach high level privacy